### PR TITLE
Changed typing to remove ambiguities

### DIFF
--- a/src/PlasmoData.jl
+++ b/src/PlasmoData.jl
@@ -9,7 +9,7 @@ export DataGraph, DataDiGraph, add_node!, add_node_data!, add_edge_data!, adjace
 export get_EC, matrix_to_graph, symmetric_matrix_to_graph, mvts_to_graph, tensor_to_graph
 export filter_nodes, filter_edges, run_EC_on_nodes, run_EC_on_edges, aggregate
 export get_node_data, get_edge_data, ne, nn, nv, remove_node!, remove_edge!
-export add_node_attribute!, add_edge_attribute!, has_edge, has_node, has_pathG
+export add_node_attribute!, add_edge_attribute!, has_edge, has_node, has_path
 export get_node_attributes, get_edge_attributes, get_path
 export nodes_to_index, index_to_nodes, average_degree, rename_graph_attribute!
 export rename_node_attribute!, rename_edge_attribute!, add_node_dataset!, add_edge_dataset!
@@ -32,10 +32,10 @@ NodeData have the following attributes:
  `data`: Matrix with the number of rows corresponding to the number of nodes in the graph
  and with a column for each attribute in `attributes`
 """
-mutable struct NodeData{T, T1, M1}
+mutable struct NodeData{T, T1, M1 <: AbstractMatrix{T1}}
     attributes::Vector{String}
     attribute_map::Dict{String, T}
-    data::AbstractMatrix{T1}
+    data::M1
 end
 
 """
@@ -52,10 +52,10 @@ EdgeData have the following attributes:
  `data`: Matrix with the number of rows corresponding to the number of edgess in the graph
  and with a column for each attribute in `attributes`
 """
-mutable struct EdgeData{T, T2, M2}
+mutable struct EdgeData{T, T2, M2 <: AbstractMatrix{T2}}
     attributes::Vector{String}
     attribute_map::Dict{String, T}
-    data::AbstractMatrix{T2}
+    data::M2
 end
 
 """
@@ -89,8 +89,8 @@ function NodeData(
     attributes::Vector{String} = Vector{String}(),
     attribute_map::Dict{String, T} = Dict{String, Int}(),
     data::M1 = Array{Float64}(undef, (0, 0))
-) where {T <: Real, T1, M1 <: AbstractMatrix{T1}}
-    NodeData{T, T1, M1}(
+) where {T <: Real, M1 <: AbstractMatrix}
+    NodeData{T, eltype(data), M1}(
         attributes,
         attribute_map,
         data
@@ -109,8 +109,8 @@ function EdgeData(
     attributes::Vector{String} = Vector{String}(),
     attribute_map::Dict{String, T} = Dict{String, Int}(),
     data::M2 = Array{Float64}(undef, (0, 0))
-) where {T <: Real, T2, M2 <: AbstractMatrix{T2}}
-    EdgeData{T, T2, M2}(
+) where {T <: Real, M2 <: AbstractMatrix}
+    EdgeData{T, eltype(data), M2}(
         attributes,
         attribute_map,
         data

--- a/src/PlasmoData.jl
+++ b/src/PlasmoData.jl
@@ -5,16 +5,52 @@ using SparseArrays
 using Statistics
 using LinearAlgebra
 
-export DataGraph, DataDiGraph, add_node!, add_node_data!, add_edge_data!, adjacency_matrix
-export get_EC, matrix_to_graph, symmetric_matrix_to_graph, mvts_to_graph, tensor_to_graph
-export filter_nodes, filter_edges, run_EC_on_nodes, run_EC_on_edges, aggregate
-export get_node_data, get_edge_data, ne, nn, nv, remove_node!, remove_edge!
-export add_node_attribute!, add_edge_attribute!, has_edge, has_node, has_path
-export get_node_attributes, get_edge_attributes, get_path
-export nodes_to_index, index_to_nodes, average_degree, rename_graph_attribute!
-export rename_node_attribute!, rename_edge_attribute!, add_node_dataset!, add_edge_dataset!
-export add_graph_data!, get_graph_data, get_graph_attributes, order_edges!
-export get_ordered_edge_data, downstream_nodes, upstream_nodes
+export DataGraph,
+    DataDiGraph,
+    add_node!,
+    add_node_data!,
+    add_edge_data!,
+    adjacency_matrix,
+    get_EC,
+    matrix_to_graph,
+    symmetric_matrix_to_graph,
+    mvts_to_graph,
+    tensor_to_graph,
+    filter_nodes,
+    filter_edges,
+    run_EC_on_nodes,
+    run_EC_on_edges,
+    aggregate,
+    get_node_data,
+    get_edge_data,
+    ne,
+    nn,
+    nv,
+    remove_node!,
+    remove_edge!,
+    add_node_attribute!,
+    add_edge_attribute!,
+    has_edge,
+    has_node,
+    has_path,
+    get_node_attributes,
+    get_edge_attributes,
+    get_path,
+    nodes_to_index,
+    index_to_nodes,
+    average_degree,
+    rename_graph_attribute!,
+    rename_node_attribute!,
+    rename_edge_attribute!,
+    add_node_dataset!,
+    add_edge_dataset!,
+    add_graph_data!,
+    get_graph_data,
+    get_graph_attributes,
+    order_edges!,
+    get_ordered_edge_data,
+    downstream_nodes,
+    upstream_nodes
 
 abstract type AbstractDataGraph{T} <: Graphs.AbstractGraph{T} end
 

--- a/src/datagraphs/core.jl
+++ b/src/datagraphs/core.jl
@@ -17,8 +17,8 @@ function DataGraph(
     edge_map::Dict{Tuple{T}, Int} = Dict{Any, Int}(),
     node_data::M1 = Array{Float64}(undef, 0, 0),
     edge_data::M2 = Array{Float64}(undef, 0, 0),
-    graph_data::Vector{T3} = Vector{Float64}()
-) where {T <: Int, T1, T2, T3, M1 <: Matrix{T1}, M2 <: Matrix{T2}}
+    graph_data::Vector = Vector{Float64}()
+) where {T <: Int, M1 <: Matrix, M2 <: Matrix}
 
     if length(edges) != ne
         error("Defined edges do not match ne")
@@ -48,11 +48,11 @@ function DataGraph(
         graph_attribute_map[graph_attributes[i]] = i
     end
 
-    node_data_struct = NodeData(node_attributes, node_attribute_map, node_data)
-    edge_data_struct = EdgeData(edge_attributes, edge_attribute_map, edge_data)
-    graph_data_struct = GraphData(graph_attributes, graph_attribute_map, graph_data)
+    node_data_struct = NodeData{T, eltype(node_data), M1}(node_attributes, node_attribute_map, node_data)
+    edge_data_struct = EdgeData{T, eltype(edge_data), M2}(edge_attributes, edge_attribute_map, edge_data)
+    graph_data_struct = GraphData{T, eltype(graph_data)}(graph_attributes, graph_attribute_map, graph_data)
 
-    DataGraph{T, M1, M2}(
+    DataGraph{T, eltype(node_data), eltype(edge_data), eltype(graph_data), M1, M2}(
         g, nodes, edges, node_map, edge_map,
         node_data_struct, edge_data_struct, graph_data_struct
     )


### PR DESCRIPTION
After running `Aqua.jl`, there were a couple structs that were typed incorrectly. These were resolved. An export term was also resolved.