### PR TITLE
Changed `aggregate` to accept generalized functions

### DIFF
--- a/src/PlasmoData.jl
+++ b/src/PlasmoData.jl
@@ -243,6 +243,10 @@ function Base.eltype(
     return eltype(eltype(dg.g.fadjlist))
 end
 
+function _default_mean(x)
+    return Statistics.mean(x; dims = 1)
+end
+
 include("datagraphs/core.jl")
 include("datadigraphs/core.jl")
 include("datadigraphs/utils.jl")

--- a/src/datadigraphs/utils.jl
+++ b/src/datadigraphs/utils.jl
@@ -353,18 +353,21 @@ function remove_edge!(
 end
 
 """
-    aggregate(datadigraph, node_list, aggregated_node_name)
+    aggregate(datagraph, node_list, aggregated_node_name; node_fn = mean, edge_fn = mean)
 
 Aggregates all the nodes in `node_list` into a single node which is called `aggregated_node_name`.
-If nodes have any weight/attribute values defined, These are averaged across all values in the
-`node_list`. Edge weights are also averaged when two or more nodes in the `node_list` are connected
-to the same node and these edges have weights defined on them.
+If nodes have any weight/attribute values defined, these values are combined via the `node_fn` function.
+The default for `node_fn` is Statistics.mean which averages the data for the nodes in `node_list`.
+Edge data are also are also combined via the `edge_fn` when two or more nodes in the `node_list` are
+connected to the same node and these edges have data defined on them. The `edge_fn` also defaults
+to `Statistics.mean`
 """
 function aggregate(
     dg::DataDiGraph,
     node_set::Vector,
     new_name::N;
-    fn::Function = _default_mean
+    node_fn::Function = _default_mean,
+    edge_fn::Function = _default_mean
 ) where {N <: Any}
 
     nodes              = dg.nodes
@@ -415,7 +418,7 @@ function aggregate(
 
     if length(node_attributes) > 0
         node_data_to_avg   = node_data[agg_node_indices, :]
-        node_weight_avg    = fn(node_data_to_avg)
+        node_weight_avg    = node_fn(node_data_to_avg)
 
         node_data_to_keep = node_data[indices_to_keep, :]
         new_node_data     = vcat(node_data_to_keep, node_weight_avg)
@@ -538,7 +541,7 @@ function aggregate(
             new_index = new_edge_map[edge]
             edge_data_to_avg = edge_data[edge_bool_avg_index[edge], :]
 
-            edge_data_avg = fn(edge_data_to_avg)
+            edge_data_avg = edge_fn(edge_data_to_avg)
             new_edge_data[new_index, :] = edge_data_avg[:]
         end
 

--- a/src/datadigraphs/utils.jl
+++ b/src/datadigraphs/utils.jl
@@ -353,7 +353,7 @@ function remove_edge!(
 end
 
 """
-    aggregate(datagraph, node_list, aggregated_node_name; node_fn = mean, edge_fn = mean)
+    aggregate(datadigraph, node_list, aggregated_node_name; node_fn = mean, edge_fn = mean)
 
 Aggregates all the nodes in `node_list` into a single node which is called `aggregated_node_name`.
 If nodes have any weight/attribute values defined, these values are combined via the `node_fn` function.

--- a/src/datadigraphs/utils.jl
+++ b/src/datadigraphs/utils.jl
@@ -363,7 +363,8 @@ to the same node and these edges have weights defined on them.
 function aggregate(
     dg::DataDiGraph,
     node_set::Vector,
-    new_name::N
+    new_name::N;
+    fn::Function = _default_mean
 ) where {N <: Any}
 
     nodes              = dg.nodes
@@ -414,7 +415,7 @@ function aggregate(
 
     if length(node_attributes) > 0
         node_data_to_avg   = node_data[agg_node_indices, :]
-        node_weight_avg    = Statistics.mean(node_data_to_avg; dims=1)
+        node_weight_avg    = fn(node_data_to_avg)
 
         node_data_to_keep = node_data[indices_to_keep, :]
         new_node_data     = vcat(node_data_to_keep, node_weight_avg)
@@ -537,7 +538,7 @@ function aggregate(
             new_index = new_edge_map[edge]
             edge_data_to_avg = edge_data[edge_bool_avg_index[edge], :]
 
-            edge_data_avg = Statistics.mean(edge_data_to_avg; dims = 1)
+            edge_data_avg = fn(edge_data_to_avg)
             new_edge_data[new_index, :] = edge_data_avg[:]
         end
 

--- a/src/datagraphs/utils.jl
+++ b/src/datagraphs/utils.jl
@@ -824,7 +824,8 @@ to the same node and these edges have weights defined on them.
 function aggregate(
     dg::DataGraph,
     node_set::Vector,
-    new_name::N
+    new_name::N;
+    fn::Function = _default_mean
 ) where {N <: Any}
     nodes              = dg.nodes
     node_map           = dg.node_map
@@ -874,7 +875,7 @@ function aggregate(
 
     if length(node_attributes) > 0
         node_data_to_avg   = node_data[agg_node_indices, :]
-        node_weight_avg    = Statistics.mean(node_data_to_avg; dims=1)
+        node_weight_avg    = fn(node_data_to_avg)
 
         node_data_to_keep = node_data[indices_to_keep, :]
         new_node_data     = vcat(node_data_to_keep, node_weight_avg)
@@ -994,7 +995,7 @@ function aggregate(
             new_index = new_edge_map[edge]
             edge_data_to_avg = edge_data[edge_bool_avg_index[edge], :]
 
-            edge_data_avg = Statistics.mean(edge_data_to_avg; dims = 1)
+            edge_data_avg = fn(edge_data_to_avg)
             new_edge_data[new_index, :] = edge_data_avg[:]
         end
 

--- a/src/datagraphs/utils.jl
+++ b/src/datagraphs/utils.jl
@@ -814,7 +814,7 @@ function remove_edge!(
 end
 
 """
-    aggregate(datagraph, node_list, aggregated_node_name; fn = mean)
+    aggregate(datagraph, node_list, aggregated_node_name; node_fn = mean, edge_fn = mean)
 
 Aggregates all the nodes in `node_list` into a single node which is called `aggregated_node_name`.
 If nodes have any weight/attribute values defined, these values are combined via the `node_fn` function.


### PR DESCRIPTION
Previously, `aggregate` for DataGraphs and DataDiGraphs would average data on nodes and edges that were impacted by the aggregation. However, in some cases, a user may have data that cannot be averaged. I changed this function so that it takes a function as an argument that will work with the data as the user defines. 