### PR TITLE
Fixed `add_edge!` conflicts

### DIFF
--- a/src/PlasmoData.jl
+++ b/src/PlasmoData.jl
@@ -8,6 +8,7 @@ using LinearAlgebra
 export DataGraph,
     DataDiGraph,
     add_node!,
+    add_edge!,
     add_node_data!,
     add_edge_data!,
     adjacency_matrix,

--- a/src/PlasmoData.jl
+++ b/src/PlasmoData.jl
@@ -5,6 +5,8 @@ using SparseArrays
 using Statistics
 using LinearAlgebra
 
+import Graphs: add_edge!
+
 export DataGraph,
     DataDiGraph,
     add_node!,

--- a/test/DataDiGraph_interface_test.jl
+++ b/test/DataDiGraph_interface_test.jl
@@ -10,7 +10,7 @@ for i in 1:length(nodes)
 end
 
 for i in 1:length(edges)
-    PlasmoData.add_edge!(dg, edges[i])
+    add_edge!(dg, edges[i])
     add_edge_data!(dg, edges[i], edge_data[i])
 end
 

--- a/test/DataDiGraph_test.jl
+++ b/test/DataDiGraph_test.jl
@@ -21,7 +21,7 @@ function build_datadigraph(nodes, edges)
         add_node!(dg, i)
     end
     for (i, j) in edges
-        PlasmoData.add_edge!(dg, i, j)
+        add_edge!(dg, i, j)
     end
     return dg
 end
@@ -108,7 +108,7 @@ end
 # Test add_edge! function 1
 
 for (i, j) in edges
-    PlasmoData.add_edge!(dg, i, j)
+    add_edge!(dg, i, j)
 end
 
 @testset "add_edge! test1" begin

--- a/test/DataDiGraph_utils_test.jl
+++ b/test/DataDiGraph_utils_test.jl
@@ -10,7 +10,7 @@ for i in 1:length(nodes)
 end
 
 for i in 1:length(edges)
-    PlasmoData.add_edge!(dg, edges[i])
+    add_edge!(dg, edges[i])
     add_edge_data!(dg, edges[i], edge_data[i])
 end
 
@@ -97,7 +97,7 @@ for i in 1:length(nodes)
 end
 
 for i in 1:length(edges)
-    PlasmoData.add_edge!(dg, edges[i])
+    add_edge!(dg, edges[i])
     add_edge_data!(dg, edges[i], edge_data[i])
 end
 

--- a/test/DataGraph_interface_test.jl
+++ b/test/DataGraph_interface_test.jl
@@ -10,7 +10,7 @@ for i in 1:length(nodes)
 end
 
 for i in 1:length(edges)
-    PlasmoData.add_edge!(dg, edges[i])
+    add_edge!(dg, edges[i])
     add_edge_data!(dg, edges[i], edge_data[i], "weight")
 end
 

--- a/test/DataGraph_test.jl
+++ b/test/DataGraph_test.jl
@@ -21,7 +21,7 @@ function build_datagraph(nodes, edges)
         add_node!(dg, i)
     end
     for (i, j) in edges
-        PlasmoData.add_edge!(dg, i, j)
+        add_edge!(dg, i, j)
     end
 
     return dg
@@ -108,7 +108,7 @@ end
 # Test add_edge! function 1
 
 for (i, j) in edges
-    PlasmoData.add_edge!(dg, i, j)
+    add_edge!(dg, i, j)
 end
 
 @testset "add_edge! test" begin
@@ -147,7 +147,7 @@ for i in nodes
 end
 
 for i in edges
-    PlasmoData.add_edge!(dg, i)
+    add_edge!(dg, i)
 end
 
 @testset "add_edge! test" begin

--- a/test/function_tests.jl
+++ b/test/function_tests.jl
@@ -13,7 +13,7 @@ for i in 1:length(nodes)
 end
 
 for i in 1:length(edges)
-    PlasmoData.add_edge!(ddg, edges[i])
+    add_edge!(ddg, edges[i])
     add_edge_data!(ddg, edges[i], edge_data[i])
 end
 


### PR DESCRIPTION
The `add_edge!` function was formerly not being exported and had conflicts with `Graphs.add_edge!`. I made sure to import the `Graphs.jl` function and export the `add_edge!` function, and now the conflicts seem resolved. 