### PR TITLE
Fixed tests to run correctly on mac

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,7 @@ jobs:
       matrix:
         julia-version: ['1.7', '1.10']
         julia-arch: [x64]
-        os: [ubuntu-latest,macos-latest,windows-latest]
-        exclude:
-         - os: macos-latest
-         - julia-version: '1.7'
-        include:
-         - os: macos-13
-         - julia-version: '1.7'
+        os: [ubuntu-latest,macos-13,windows-latest]
     steps:
       - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: ['1.7', '1.10']
+        julia-version: ['1.10']
         julia-arch: [x64]
-        os: [ubuntu-latest,macos-13,windows-latest]
+        os: [ubuntu-latest,macos-latest,windows-latest]
     steps:
       - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@latest


### PR DESCRIPTION
There is an issue with using macos-latest in the yml workflow for tests when using Julia 1.7 or Julia 1.6. I updated the os to be macos-13 per the recommendation [here](https://discourse.julialang.org/t/how-to-fix-github-actions-ci-failures-with-julia-1-6-or-1-7-on-macos-latest-and-macos-14/117019). 